### PR TITLE
Avoid hard tab indentation, use space instead.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -13,5 +13,3 @@ use Mix.Config
 # here (which is why it is important to import them last).
 
 import_config "#{Mix.env}.exs"
-
-

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,2 +1,1 @@
 use Mix.Config
-

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,18 +4,17 @@ use Mix.Config
 # behavior for testing rather than using sys/class/leds
 
 config :nerves_io_led, names: [
-	test_led: &Nerves.IO.LedTest.on_led_write/1
+  test_led: &Nerves.IO.LedTest.on_led_write/1
 ]
 
 # redefine led state map to be default, but with an additional custom
 # state to handle test_states
 
 config :nerves_io_led, states: [
-		true:  [ brightness: 1 ],
-    false: [ brightness: 0 ],
-		slowblink: [ trigger: "timer", delay_off: 250, delay_on: 250 ],
-		fastblink: [ trigger: "timer", delay_off: 80, delay_on: 50 ],
-		slowwink:  [ trigger: "timer", delay_on: 1000, delay_off: 100 ],
-		heartbeat: [ trigger: "heartbeat" ],
-    test_state: [ foo: 3, bar: 29, baz: %{} ]
-]
+  true: [brightness: 1],
+  false: [brightness: 0],
+  slowblink: [trigger: "timer", delay_off: 250, delay_on: 250],
+  fastblink: [trigger: "timer", delay_off: 80, delay_on: 50],
+  slowwink: [trigger: "timer", delay_on: 1000, delay_off: 100],
+  heartbeat: [trigger: "heartbeat"],
+  test_state: [foo: 3, bar: 29, baz: %{}]]

--- a/test/nerves_led_test.exs
+++ b/test/nerves_led_test.exs
@@ -3,7 +3,7 @@ defmodule Nerves.IO.LedTest do
   use ExUnit.Case
   alias Nerves.IO.Led
 
-	# callback for the test led that simply sets keys in the process dictionary
+  # callback for the test led that simply sets keys in the process dictionary
   # where we can assert them.  This works because the LED module does
   # everything in process.
   def on_led_write({k, v}), do: Process.put(k, v)
@@ -11,29 +11,28 @@ defmodule Nerves.IO.LedTest do
   defp led(key), do: Process.get(key)
 
   test "turning on an LED" do
-		Led.set test_led: true
-	  assert led(:brightness) == 1
-		assert led(:trigger) == "none"
+    Led.set test_led: true
+    assert led(:brightness) == 1
+    assert led(:trigger) == "none"
   end
 
   test "turn off an LED" do
-		Led.set test_led: false
-	  assert led(:brightness) == 0
-		assert led(:trigger) == "none"
+    Led.set test_led: false
+    assert led(:brightness) == 0
+    assert led(:trigger) == "none"
   end
 
   test "test a complex state" do
-		Led.set test_led: :slowwink
-		assert led(:trigger) == "timer"
-		assert led(:delay_on) == 1000
+    Led.set test_led: :slowwink
+    assert led(:trigger) == "timer"
+    assert led(:delay_on) == 1000
     assert led(:delay_off) == 100
   end
 
   test "custom state map" do
-		Led.set test_led: :test_state
-		assert led(:foo) == 3
+    Led.set test_led: :test_state
+    assert led(:foo) == 3
     assert led(:bar) == 29
     assert led(:baz) == %{}
   end
-
 end


### PR DESCRIPTION
Also, try to avoid trailing blank lines at the end of the file
