### PR TITLE
add parentheses to allow older elixir builds to compile

### DIFF
--- a/lib/nerves_leds.ex
+++ b/lib/nerves_leds.ex
@@ -114,7 +114,7 @@ defmodule Nerves.Leds do
   end
 
   defp raw_state(val) when is_list(val), do: val
-  defp raw_state(val), do: Dict.get @led_states, val
+  defp raw_state(val), do: Dict.get(@led_states, val)
 
   defp raw_led(key) do
     case (Dict.get @led_names, key) do


### PR DESCRIPTION
The title says it all... Elixir 1.0.4 will not compile module do to missing parentheses
