### PR TITLE
cleanup, removing compile-time config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: elixir
 elixir:
-  - 1.1.0
+  - 1.4.1
 otp_release:
-  - 18.0
+  - 19.0
 sudo: false
 before_script:
   - mix deps.get --only test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.8.0-dev (2017-02-22)
+
+* Specifying string for LED name to set function now bypasses name mapping
+* Removed all compile-time config cacheing to avoid deps issues
+* Now raises ArgumentError for invalid states
+* Added alternate single-LED API form `set/2`
+* Simplified README
+
 ## v0.7.0 (2016-06-21)
 
 This update reflects a number of changes that bring this module more in line

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, 2016 Garth Hitchens
+Copyright (c) 2015-2017 Garth Hitchens
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,69 +1,61 @@
 Nerves.Leds
 ===========
 [![Build Status](https://travis-ci.org/nerves-project/nerves_io_led.svg?branch=master)](https://travis-ci.org/nerves-project/nerves_leds)
+[![Hex version](https://img.shields.io/hexpm/v/nerves_leds.svg "Hex version")](https://hex.pm/packages/nerves_uart) [![Ebert](https://ebertapp.io/github/nerves-project/nerves_leds.svg)](https://ebertapp.io/github/nerves-project/nerves_leds)
 
-Simple API to drive leds exposed by linux `/sys/class/leds`.
-Designed for use with [nerves](http://nerves-project.org/),
-but works on any distribution of Linux that supports `/sys/class/leds`.
+Simple API to drive leds exposed by linux `/sys/class/leds`.  Designed for use with [Nerves](http://nerves-project.org/), but works on any distribution of Linux with `/sys/class/leds`.
 
-## Configuration
+## Installation
 
-Use config.exs to create a friendly name that maps to an entry in
-`/sys/class/leds` that make sense for your application.
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
 
-An example configuration for the Alix 2D boards:
+  1. Add `nerves_leds` to your list of dependencies in `mix.exs`:
+
+  ```elixir
+  def deps do
+    [{:nerves_leds, "~> 0.1.1"}]
+  end
+  ```
+
+  2. List `:nerves_leds` as an application dependency:
+
+  ```elixir
+  def application do
+    [applications: [:nerves_leds]]
+  end
+  ```
+
+  4. Run `mix deps.get` and `mix compile`
+
+
+### Configuration & Usage
+
+Configure your LEDs mappings:
 
 ```elixir
-# in your app's config/config.exs:
-config :nerves_leds, names: [
-	power:     "alix:1",
-	connected: "alix:2",
-	alert:     "alix:3"
-]
+# config/config.exs
+config :nerves_leds, names: [ error: "led0", connect: "led1" ]
 ```
-## Usage
 
-It's customary to bring the Nerves.Leds module into scope as "Leds", as follows:
+Now, you can use predefined states in your app:
+
 ```elixir
 alias Nerves.Leds
-```
-Now, we can turn an LED on using the name we configured:
-```elixir
-Leds.set power: true
-```
-Or make it blink slowly:
-```elixir
-Leds.set power: :slowblink
-```
-We can even set multiple states for multiple LEDs at once:
-```elixir
-Leds.set connected: false, alert: :fastblink
-```
-## Built-In LED States
 
-In addition to `true` (on) and `false` (off) the following atoms provide predefined
-behaviors:
+Leds.set connect: true
+Leds.set connect: :heartbeat
+Leds.set connect: false, error: :slowlbink
+```
 
-- `:slowblink` - turns on and off slowly (about twice a second)
-- `:fastblink` - turns on and off rapidly (about 7.5 times a second)
-- `:slowwink` - mostly on, but "winks off" once every second or so
-- `:hearbeat` - a heartbeat pattern
-
-## Customizing states
-
-The standard LED states are defined as `@predefined_states` near the top of
-`lib/nerves_leds.ex`. You can change or add to them using config.exs as
-follows:
+You can also define your own states:
 
 ```elixir
+# config/config.exs
 config :nerves_leds, states: [
 	fastblink: [ trigger: "timer", delay_off: 40, delay_on: 30 ],
 	blip: [ trigger: "timer", delay_off: 1000, delay_on: 100 ]]
 ```
 
-See the Linux documentation on `sys/class/leds` to understand the meaning of
-trigger, delay, brightness, and other settings.
+### More Details
 
-## Limitations, Areas for Improvement
-
-- most but not all ``/sys/class/leds` features are currently implemented
+See the [documentation](https://hexdocs.pm/nerves_leds) for the full description of the API and configuration.

--- a/lib/nerves_leds.ex
+++ b/lib/nerves_leds.ex
@@ -72,12 +72,12 @@ defmodule Nerves.Leds do
   @app :nerves_leds
 
   @predefined_states [
-    true:  [ brightness: 1 ],
-    false: [ brightness: 0 ],
-    slowblink: [ trigger: "timer", delay_off: 250, delay_on: 250 ],
-    fastblink: [ trigger: "timer", delay_off: 80, delay_on: 50 ],
-    slowwink:  [ trigger: "timer", delay_on: 1000, delay_off: 100 ],
-    heartbeat: [ trigger: "heartbeat" ]
+    true:  [brightness: 1],
+    false: [brightness: 0],
+    slowblink: [trigger: "timer", delay_off: 250, delay_on: 250],
+    fastblink: [trigger: "timer", delay_off: 80, delay_on: 50],
+    slowwink:  [trigger: "timer", delay_on: 1000, delay_off: 100],
+    heartbeat: [trigger: "heartbeat"]
   ]
 
   @sys_leds_path "/sys/class/leds/"
@@ -137,7 +137,7 @@ defmodule Nerves.Leds do
   defp set_raw_state(led, settings) do
     {trigger, settings} = Keyword.pop settings, :trigger, "none"
     write(led, {:trigger, trigger})
-    Enum.each settings, &(led |> write(&1))
+    Enum.each settings, &(write(led, &1))
   end
 
   # if parameter isn't a list, lookup state from state map or predefined states

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,13 @@
 defmodule Nerves.Leds.Mixfile do
 
-  @version "0.7.0"
+  @version "0.8.0-dev"
 
   use Mix.Project
 
   def project do
     [ app: :nerves_leds,
       version: @version,
-      elixir: "~> 1.0",
+      elixir: "~> 1.4",
       deps: deps(),
       description: "Functions to drive LEDs on embedded systems",
       package: package(),
@@ -16,7 +16,6 @@ defmodule Nerves.Leds.Mixfile do
       docs: [
         source_ref: "v#{@version}", main: "Nerves.Leds",
         source_url: "https://github.com/nerves-project/nerves_leds",
-#       main: "extra-readme",
         extras: [ "README.md", "CHANGELOG.md"] ]]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Nerves.Leds.Mixfile do
       docs: [
         source_ref: "v#{@version}", main: "Nerves.Leds",
         source_url: "https://github.com/nerves-project/nerves_leds",
-        extras: [ "README.md", "CHANGELOG.md"]]]
+        extras: ["README.md", "CHANGELOG.md"]]]
   end
 
   def application do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Nerves.Leds.Mixfile do
   use Mix.Project
 
   def project do
-    [ app: :nerves_leds,
+    [app: :nerves_leds,
       version: @version,
       elixir: "~> 1.4",
       deps: deps(),
@@ -16,7 +16,7 @@ defmodule Nerves.Leds.Mixfile do
       docs: [
         source_ref: "v#{@version}", main: "Nerves.Leds",
         source_url: "https://github.com/nerves-project/nerves_leds",
-        extras: [ "README.md", "CHANGELOG.md"] ]]
+        extras: [ "README.md", "CHANGELOG.md"]]]
   end
 
   def application do
@@ -28,10 +28,10 @@ defmodule Nerves.Leds.Mixfile do
   end
 
   defp package do
-    [ maintainers: ["Garth Hitchens", "Chris Dutton"],
+    [maintainers: ["Garth Hitchens", "Chris Dutton"],
       licenses: ["MIT"],
       links: %{github: "https://github.com/nerves-project/nerves_leds"},
-      files: ~w(lib config) ++ ~w(README.md CHANGELOG.md LICENSE mix.exs) ]
+      files: ~w(lib config) ++ ~w(README.md CHANGELOG.md LICENSE mix.exs)]
   end
 
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]}}
+%{"earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]}}

--- a/test/nerves_leds_test.exs
+++ b/test/nerves_leds_test.exs
@@ -29,6 +29,13 @@ defmodule Nerves.Leds.Test do
     assert led(:delay_off) == 100
   end
 
+  test "test single LED api" do
+    Leds.set :test_led, brightness: 202, trigger: "none", delay_on: 500
+    assert led(:trigger) == "none"
+    assert led(:delay_on) == 500
+    assert led(:brightness) == 202
+  end
+
   test "custom state map" do
     Leds.set test_led: :test_state
     assert led(:foo) == 3


### PR DESCRIPTION
* Specifying string for LED name to set function now bypasses name mapping
* Removed all compile-time config cacheing to avoid deps issues
* Now raises ArgumentError for invalid states
* Added alternate single-LED API form `set/2`
* Simplified README
