### PR TITLE
Remove not working part of code for integer values

### DIFF
--- a/lib/nerves_leds.ex
+++ b/lib/nerves_leds.ex
@@ -157,7 +157,6 @@ defmodule Nerves.Leds do
 
   # if parameter isn't a list, lookup state from state map or predefined states
   defp raw_state(val) when is_list(val), do: val
-  defp raw_state(val) when is_integer(val), do: Integer.to_string(val)
 
   defp raw_state(val) when is_atom(val) do
     @app


### PR DESCRIPTION
This line does fail, because the returned value is not a keyword list. I've removed it as it seems to be nothing, which is even intended to work in the first place.